### PR TITLE
fix: remove extra quotes from profile, region, external_id, aws_cli_query params

### DIFF
--- a/scripts/aws_cli_runner.sh
+++ b/scripts/aws_cli_runner.sh
@@ -26,12 +26,12 @@ REGION_NAME=$(echo "${TERRAFORM_QUERY}" | jq -r '.region')
 
 # Do we have a profile?
 if [ -n "${PROFILE_NAME}" ]; then
-  AWS_CLI_PROFILE_PARAM="--profile '${PROFILE_NAME}'"
+  AWS_CLI_PROFILE_PARAM="--profile=${PROFILE_NAME}"
 fi
 
 # Do we have a region?
 if [ -n "${REGION_NAME}" ]; then
-  AWS_CLI_REGION_PARAM="--region= '${REGION_NAME}'"
+  AWS_CLI_REGION_PARAM="--region=${REGION_NAME}"
 fi
 
 # Do we need to assume a role?
@@ -39,7 +39,7 @@ if [ -n "${ASSUME_ROLE_ARN}" ]; then
 
   # Do we have an external ID?
   if [ -n "${EXTERNAL_ID}" ]; then
-    AWS_CLI_EXTERNAL_ID_PARAM="--external-id '${EXTERNAL_ID}'"
+    AWS_CLI_EXTERNAL_ID_PARAM="--external-id=${EXTERNAL_ID}"
   fi
 
   TEMP_ROLE=$(aws sts assume-role ${AWS_CLI_PROFILE_PARAM:-} ${AWS_CLI_REGION_PARAM:-} --output json --role-arn "${ASSUME_ROLE_ARN}" ${AWS_CLI_EXTERNAL_ID_PARAM:-} --role-session-name "${ROLE_SESSION_NAME:-AssumingRole}")

--- a/scripts/aws_cli_runner.sh
+++ b/scripts/aws_cli_runner.sh
@@ -26,12 +26,12 @@ REGION_NAME=$(echo "${TERRAFORM_QUERY}" | jq -r '.region')
 
 # Do we have a profile?
 if [ -n "${PROFILE_NAME}" ]; then
-  AWS_CLI_PROFILE_PARAM="--profile '${PROFILE_NAME}'"
+  AWS_CLI_PROFILE_PARAM="--profile ${PROFILE_NAME}"
 fi
 
 # Do we have a region?
 if [ -n "${REGION_NAME}" ]; then
-  AWS_CLI_REGION_PARAM="--region '${REGION_NAME}'"
+  AWS_CLI_REGION_PARAM="--region ${REGION_NAME}"
 fi
 
 # Do we need to assume a role?
@@ -39,7 +39,7 @@ if [ -n "${ASSUME_ROLE_ARN}" ]; then
 
   # Do we have an external ID?
   if [ -n "${EXTERNAL_ID}" ]; then
-    AWS_CLI_EXTERNAL_ID_PARAM="--external-id '${EXTERNAL_ID}'"
+    AWS_CLI_EXTERNAL_ID_PARAM="--external-id ${EXTERNAL_ID}"
   fi
 
   TEMP_ROLE=$(aws sts assume-role ${AWS_CLI_PROFILE_PARAM:-} ${AWS_CLI_REGION_PARAM:-} --output json --role-arn "${ASSUME_ROLE_ARN}" ${AWS_CLI_EXTERNAL_ID_PARAM:-} --role-session-name "${ROLE_SESSION_NAME:-AssumingRole}")
@@ -50,7 +50,7 @@ fi
 
 # Do we have a query?
 if [ -n "${AWS_CLI_QUERY}" ]; then
-  AWS_CLI_QUERY_PARAM="--query '${AWS_CLI_QUERY}'"
+  AWS_CLI_QUERY_PARAM="--query ${AWS_CLI_QUERY}"
 fi
 
 # Do we want to be debug?

--- a/scripts/aws_cli_runner.sh
+++ b/scripts/aws_cli_runner.sh
@@ -26,12 +26,12 @@ REGION_NAME=$(echo "${TERRAFORM_QUERY}" | jq -r '.region')
 
 # Do we have a profile?
 if [ -n "${PROFILE_NAME}" ]; then
-  AWS_CLI_PROFILE_PARAM="--profile ${PROFILE_NAME}"
+  AWS_CLI_PROFILE_PARAM="--profile '${PROFILE_NAME}'"
 fi
 
 # Do we have a region?
 if [ -n "${REGION_NAME}" ]; then
-  AWS_CLI_REGION_PARAM="--region ${REGION_NAME}"
+  AWS_CLI_REGION_PARAM="--region= '${REGION_NAME}'"
 fi
 
 # Do we need to assume a role?
@@ -39,7 +39,7 @@ if [ -n "${ASSUME_ROLE_ARN}" ]; then
 
   # Do we have an external ID?
   if [ -n "${EXTERNAL_ID}" ]; then
-    AWS_CLI_EXTERNAL_ID_PARAM="--external-id ${EXTERNAL_ID}"
+    AWS_CLI_EXTERNAL_ID_PARAM="--external-id '${EXTERNAL_ID}'"
   fi
 
   TEMP_ROLE=$(aws sts assume-role ${AWS_CLI_PROFILE_PARAM:-} ${AWS_CLI_REGION_PARAM:-} --output json --role-arn "${ASSUME_ROLE_ARN}" ${AWS_CLI_EXTERNAL_ID_PARAM:-} --role-session-name "${ROLE_SESSION_NAME:-AssumingRole}")
@@ -50,7 +50,7 @@ fi
 
 # Do we have a query?
 if [ -n "${AWS_CLI_QUERY}" ]; then
-  AWS_CLI_QUERY_PARAM="--query ${AWS_CLI_QUERY}"
+  AWS_CLI_QUERY_PARAM="--query '${AWS_CLI_QUERY}'"
 fi
 
 # Do we want to be debug?


### PR DESCRIPTION
Hey guys, great module and solves some specific pain points we're having around rendering certain data sets from AWS. I believe I've discovered a small bug while trying to use the latest version of the module however (please correct me if I'm wrong).

**Context:**
```
Terraform v1.6.5
on darwin_arm64
+ provider registry.terraform.io/hashicorp/aws v5.30.0
```

I instantiate the module using code like:
```
module "my_module" {
  source  = "digitickets/cli/aws"
  version = "5.2.0"
  region = "MY_REGION"
  assume_role_arn = "MY_ROLE_ARN"

  aws_cli_commands = [
    "aws", 
    "commands", 
    "go", 
    "here"
  ]
}
```
but applying the module throws the following error:
```
The data source received an unexpected error while attempting to execute the program.
│ 
│ Program: .terraform/modules/a_module.my_module/scripts/aws_cli_runner.sh
│ Error Message: 
│ Provided region_name ''MY_REGION'' doesn't match a supported format.
```

You'll note that there are two sets of single-quotes on either side of `MY_REGION` - I believe the way that your script handles this parameter (and likely a few others that are handled similarly) is the root cause. After running a `terraform init` to pull the module, if I manually make the changes to the script that this PR is incorporating, then your module runs without an issue and returns the desired `result`. In other words, the `region` parameter is correctly interpreted by the script after this change. 

Please review the issue and let me know if there is any additional information that you need. If not, I would appreciate you merging this PR so that we can put the module to use using the region parameter as intended. Thanks :)
