### PR TITLE
V7.0.1 - 2025/04/28

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Changelog
 
-# Unreleased
+# V7.0.1 - 2025/04/28
 - Add v1.11.3, and reduced the number of builds to just the latest in the minor versions of Terraform from 1.6.0 onwards.
 - Minor reorganization to match [Terraform Standard Module Structure](https://www.terraform.io/docs/modules/index.html#standard-module-structure).
 - Small enhancement for TFLint when aliased providers are used.
+- Added warning to README.md regarding destructive use. Thank you, [Yves Vogl](https://github.com/digitickets/terraform-aws-cli/issues/25).
 
 # v7.0.0 - 2024/08/06
 - Fix a typo in the description for the `var.external_id`.

--- a/README.md
+++ b/README.md
@@ -91,6 +91,24 @@ module "current_desired_capacity" {
 
 Further information regarding the use of external IDs can be found [here](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html).
 
+# Warning
+
+This module uses Terraform's `external` provider to allow an `external` data source to be used to call the AWS CLI tool,
+and retrieve information not yet available via the AWS Terraform Provider.
+
+As per the warnings [here](https://registry.terraform.io/providers/hashicorp/external/latest/docs/data-sources/external),
+the `external` data source, and as a consequence, this module, it is expected that this module is used with caution.
+
+This module is _NOT_ a replacement for the AWS Terraform Provider.
+
+As per the last paragraph of the warnings from the official documentation regarding the `external` data source...
+
+  "Terraform expects a data source to have _no observable side-effects_,
+   and will re-run the program each time the state is refreshed."
+
+If you use this module to perform destructive changes to your AWS environment, then they will be triggered each time a
+Terraform plan and apply are run.
+
 # Terraform requirements, providers, resources, etc.
 
 <!-- BEGIN_TF_DOCS -->


### PR DESCRIPTION
Add v1.11.3, and reduced the number of builds to just the latest in the minor versions of Terraform from 1.6.0 onwards.
Minor reorganization to match Terraform Standard Module Structure.
Small enhancement for TFLint when aliased providers are used.
Added warning to README.md regarding destructive use. Thank you, Yves Vogl.